### PR TITLE
Refactor: BookCard 컴포넌트 역할 분리, 조건 명명, 에러 이미지 경로 상수화

### DIFF
--- a/FE/src/components/BookDisplay/BookCard/BookCard.tsx
+++ b/FE/src/components/BookDisplay/BookCard/BookCard.tsx
@@ -13,55 +13,74 @@ interface BookItemProps {
 }
 
 const BookCard = ({ bookData, viewMode }: BookItemProps) => {
-    const { bookname, authors, publisher, publication_year, bookImageURL, loan_count, isbn13 } = bookData;
     const [isVisible, setIsVisible] = useState(false);
-    const navigate = useNavigate()
 
     useEffect(() => {
         const timer = setTimeout(() => setIsVisible(true), ANIMATION_TIME);
         return () => clearTimeout(timer);
     }, []);
 
+    return viewMode === "grid" ? (
+        <GridCard bookData={bookData} isVisible={isVisible}/>
+    ) : (
+        <ListCard bookData={bookData} isVisible={isVisible}/>
+    )
+};
+
+interface CardProps {
+    bookData: BookDoc;
+    isVisible: boolean;
+}
+
+const GridCard = ({ bookData, isVisible }: CardProps) => {
+    const {isbn13, bookImageURL, bookname, authors} = bookData
+    const navigate = useNavigate()
     return (
-        <>
-            {viewMode === "grid" ? (
-                <GridCard $isVisible={isVisible} onClick={() => navigate(`/book/${isbn13}`)}>
-                    <FavoritesBtnWrap>
-                        <FavoriteBtn item={bookData} />
-                    </FavoritesBtnWrap>
-                    <Image
-                        src={bookImageURL || ERROR_IMG}
-                        alt={bookname}
-                        onError={handleImageError}
-                        loading="lazy"
-                    />
-                    <TextContainer $viewMode="grid">
-                        <Title>{bookname}</Title>
-                        <Subtitle>{authors}</Subtitle>
-                    </TextContainer>
-                </GridCard>
-            ) : (
-                <ListCard $isVisible={isVisible} onClick={() => navigate(`/book/${isbn13}`)}>
-                    <FavoritesBtnWrap>
-                        <FavoriteBtn item={bookData} />
-                    </FavoritesBtnWrap>
-                    <Image
-                        src={bookImageURL || ERROR_IMG}
-                        alt={bookname}
-                        onError={handleImageError}
-                    />
-                    <ListBookInfo>
-                        <ListTitle>{bookname}</ListTitle>
-                        <MetaInfo>저자: {authors}</MetaInfo>
-                        <MetaInfo>출판사: {publisher}</MetaInfo>
-                        <MetaInfo>출판일: {publication_year}</MetaInfo>
-                        <LibrariesCount>
-                            대출 권수: {loan_count}
-                        </LibrariesCount>
-                    </ListBookInfo>
-                </ListCard>
-            )}
-        </>
+        <GridCardStyled
+            $isVisible={isVisible}
+            onClick={() => navigate(`/book/${isbn13}`)}
+        >
+            <FavoritesBtnWrap>
+                <FavoriteBtn item={bookData} />
+            </FavoritesBtnWrap>
+            <Image
+                src={bookImageURL || ERROR_IMG}
+                alt={bookname}
+                onError={handleImageError}
+                loading="lazy"
+            />
+            <TextContainer $viewMode="grid">
+                <Title>{bookname}</Title>
+                <Subtitle>{authors}</Subtitle>
+            </TextContainer>
+        </GridCardStyled>
+    );
+};
+
+const ListCard = ({ bookData, isVisible }: CardProps) => {
+    const {isbn13, bookImageURL, bookname, authors, publisher, publication_year, loan_count} = bookData
+    const navigate = useNavigate()
+    return (
+        <ListCardStyled
+            $isVisible={isVisible}
+            onClick={() => navigate(`/book/${isbn13}`)}
+        >
+            <FavoritesBtnWrap>
+                <FavoriteBtn item={bookData} />
+            </FavoritesBtnWrap>
+            <Image
+                src={bookImageURL || ERROR_IMG}
+                alt={bookname}
+                onError={handleImageError}
+            />
+            <ListBookInfo>
+                <ListTitle>{bookname}</ListTitle>
+                <MetaInfo>저자: {authors}</MetaInfo>
+                <MetaInfo>출판사: {publisher}</MetaInfo>
+                <MetaInfo>출판일: {publication_year}</MetaInfo>
+                <LibrariesCount>대출 권수: {loan_count}</LibrariesCount>
+            </ListBookInfo>
+        </ListCardStyled>
     );
 };
 
@@ -87,12 +106,12 @@ const Card = styled.div<{ $isVisible: boolean }>`
     }
 `;
 
-const GridCard = styled(Card)`
+const GridCardStyled = styled(Card)`
     width: 150px;
     text-align: center;
 `;
 
-const ListCard = styled(Card)`
+const ListCardStyled = styled(Card)`
     display: flex;
     margin-bottom: 1rem;
 `;

--- a/FE/src/components/BookDisplay/BookCard/BookCard.tsx
+++ b/FE/src/components/BookDisplay/BookCard/BookCard.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-import { ANIMATION_TIME } from "@/constants";
+import { ANIMATION_TIME, ERROR_IMG } from "@/constants";
 import { ViewType } from "@/types/booksType";
 import { BookDoc } from "@/types/booksType";
 import { handleImageError } from "@/utils";
@@ -30,7 +30,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
                         <FavoriteBtn item={bookData} />
                     </FavoritesBtnWrap>
                     <Image
-                        src={bookImageURL || "/images/errorImg.png"}
+                        src={bookImageURL || ERROR_IMG}
                         alt={bookname}
                         onError={handleImageError}
                         loading="lazy"
@@ -46,7 +46,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
                         <FavoriteBtn item={bookData} />
                     </FavoritesBtnWrap>
                     <Image
-                        src={bookImageURL || "/images/errorImg.png"}
+                        src={bookImageURL || ERROR_IMG}
                         alt={bookname}
                         onError={handleImageError}
                     />
@@ -65,9 +65,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
     );
 };
 
-
 export default BookCard;
-
 
 const Card = styled.div<{ $isVisible: boolean }>`
     position: relative;

--- a/FE/src/components/BookDisplay/BookDisplay.tsx
+++ b/FE/src/components/BookDisplay/BookDisplay.tsx
@@ -28,6 +28,9 @@ const BookDisplay = () => {
             </BookContainer>
         );
     }
+    const isLoadingNextPage = isFetchingNextPage && !isLastPage
+    const isEmptyContent = booksItem.length === 0 && !isFetchingNextPage
+    const isLastPageView = !hasNextPage && !isEmptyContent;
 
     return (
         <BookContainer>
@@ -46,18 +49,10 @@ const BookDisplay = () => {
                     />
                 ))}
             </BookWrap>
-            {isFetchingNextPage && !isLastPage && <LoadingSpin />}
-            {booksItem.length === 0 && !isFetchingNextPage ? (
-                <EmptyContentText>검색 결과가 없습니다.</EmptyContentText>
-            ) : (
-                <>
-                    {hasNextPage ? (
-                        <div ref={observerRef} style={{ height: "10px" }} />
-                    ) : (
-                        <LastPageView>마지막 페이지 입니다.</LastPageView>
-                    )}
-                </>
-            )}
+            {isLoadingNextPage && <LoadingSpin />}
+            {isEmptyContent && <EmptyContentText>검색 결과가 없습니다.</EmptyContentText>}
+            {isLastPageView && <LastPageView>마지막 페이지 입니다.</LastPageView>}
+            {!isEmptyContent && hasNextPage && <div ref={observerRef} style={{ height: "10px" }} />}
             <Spacing height="xl" />
         </BookContainer>
     );

--- a/FE/src/components/Detail/BookDetailCard/BookDetailCard.tsx
+++ b/FE/src/components/Detail/BookDetailCard/BookDetailCard.tsx
@@ -9,6 +9,7 @@ import { ShopOutlined } from "@ant-design/icons";
 import { Button, Heading, Spacing, Text } from "@components/Common";
 import styled from "styled-components";
 
+import { ERROR_IMG } from "@/constants";
 import useOpen from "@/hooks/Common/useOpen";
 import { BookDetailType } from "@/types/bookDetailType";
 import { handleImageError } from "@/utils";
@@ -44,7 +45,7 @@ const BookDetailCard = ({ bookData }: BookDetailCardProps) => {
             <CardContent>
                 <BookImageWrapper>
                     <StyledImage
-                        src={bookImageURL || "/images/errorImg.png"}
+                        src={bookImageURL || ERROR_IMG}
                         onError={handleImageError}
                         alt={bookname}
                         width={200}

--- a/FE/src/constants/index.ts
+++ b/FE/src/constants/index.ts
@@ -52,3 +52,4 @@ export const INITIAL_CHAT_MESSAGE: ChatHistory[] = [
 export const ANIMATION_TIME = 100;
 export const FIRST_PAGE = 1;
 export const DEFAULT_INDEX = 0;
+export const ERROR_IMG = "/images/errorImg.png"

--- a/FE/src/utils/index.ts
+++ b/FE/src/utils/index.ts
@@ -1,8 +1,9 @@
 import React from "react";
 
+import { ERROR_IMG } from "@/constants";
 export const handleImageError = (
     e: React.SyntheticEvent<HTMLImageElement>,
-    fallbackSrc: string = "/images/errorImg.png"
+    fallbackSrc: string = ERROR_IMG
 ) => {
     e.currentTarget.src = fallbackSrc;
     e.currentTarget.style.objectFit = "cover";


### PR DESCRIPTION
# PR 제목
- BookCard 컴포넌트 역할 분리, 조건 명명, 에러 이미지 경로 상수화

---

## 📌 배경
- BookCard에서 그리드와 리스트 역할이 혼재되어 조건부 렌더링으로 인해 가독성이 저하되고 유지보수가 어려운 상태였습니다.
- BookDisplay의 조건식이 복잡하게 작성되어 있어 코드를 읽기 어렵고 의도가 명확하지 않았습니다.
- 에러 이미지 경로가 하드코딩되어 재사용성과 관리 효율성이 떨어지는 문제가 있었습니다.
- #64 

## 🎯 주요 변경 사항
1. GridViewCard와 ListViewCard 분리:
  - BookCard에서 그리드와 리스트 역할을 각각 GridViewCard와 ListViewCard로 분리하여 역할을 명확히 구분.
  - viewMode에 따라 적절한 컴포넌트를 조건부로 렌더링하도록 개선.
2. 조건 명명 및 가독성 개선:
  - BookDisplay에서 isLoadingNextPage, isEmptyContent, isLastPageView와 같이 조건에 의미 있는 이름을 부여.
  - JSX 구조 간소화로 중첩된 삼항 연산자를 제거하고 의도를 명확히 표현.
3. 에러 이미지 경로 상수화:
  - 에러 이미지 경로를 ERROR_IMG 상수로 분리하여 모든 컴포넌트에서 동일한 경로를 참조하도록 통일.
  - 코드의 재사용성과 유지보수성을 향상.

---

## 🔗 참고 자료
- [frontend-fundamentals](https://frontend-fundamentals.com/)

---

## ✅ 체크리스트
- [ X] GridViewCard와 ListViewCard 역할 분리 완료
- [X] 조건 명명 및 JSX 구조 간소화 완료
- [X] 에러 이미지 경로 상수화 완료
- [X] 자체 테스트