### PR TITLE
refactor: jscodeshift 적용하여 UI 컴포넌트 Base* 네이밍 일괄 변경

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.12.0",
+        "jscodeshift": "^17.3.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.15.0",
         "vite": "^6.0.1"
@@ -160,14 +161,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -213,16 +215,30 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -244,28 +260,20 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -274,38 +282,133 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -324,18 +427,168 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
+      "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+      "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
+      "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-flow": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+      "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+      "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
@@ -368,6 +621,84 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
+      "integrity": "sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-flow-strip-types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.27.1.tgz",
+      "integrity": "sha512-K13lQpoV54LATKkzBpBAEu1GGSIRzxR9f4IN4V8DCDgiUMo2UDGagEZr3lPeVNJPLkWUi5JE4hCHKneVTwQlYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
@@ -380,30 +711,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -421,13 +754,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2482,6 +2816,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async-error-boundary": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-error-boundary/-/async-error-boundary-1.0.0.tgz",
@@ -2579,6 +2926,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -2723,6 +3077,21 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2757,6 +3126,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.0",
@@ -3587,6 +3963,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3735,6 +4125,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3769,6 +4174,16 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true
+    },
+    "node_modules/flow-parser": {
+      "version": "0.273.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.273.1.tgz",
+      "integrity": "sha512-UTTfeYIhxYJ7xuW+HL9oyx6lnUGx1+W5Cyo8hOPgMrDU49GANfONtkb9dguDvIyQ20fz8CHZwB25ZP2206bBWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -4532,6 +4947,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
@@ -4677,6 +5105,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -4701,6 +5139,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jscodeshift": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.3.0.tgz",
+      "integrity": "sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.7",
+        "neo-async": "^2.5.0",
+        "picocolors": "^1.0.1",
+        "recast": "^0.23.11",
+        "tmp": "^0.2.3",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4760,6 +5239,16 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -5065,6 +5554,30 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/markdown-table": {
@@ -5984,6 +6497,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -6133,6 +6653,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6219,6 +6749,105 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7032,6 +7661,23 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/recharts": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.14.1.tgz",
@@ -7388,6 +8034,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -7432,12 +8091,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -7724,6 +8417,16 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -8316,6 +9019,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/yallist": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "jscodeshift": "^17.3.0",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^6.0.1"

--- a/FE/src/components/AIChatPopup/AIChatBox/AIChatBox.tsx
+++ b/FE/src/components/AIChatPopup/AIChatBox/AIChatBox.tsx
@@ -1,5 +1,6 @@
 import { OpenAIOutlined, UserOutlined, SendOutlined } from "@ant-design/icons";
-import { Text } from "@components/ui";
+import { BaseText } from "@components/ui";
+import { BaseButton } from "@components/ui";
 import { Spin } from "antd";
 import React, {
   Dispatch,
@@ -14,7 +15,6 @@ import remarkGfm from "remark-gfm";
 import styled, { keyframes } from "styled-components";
 import twc from "tailwind-styled-components";
 
-import { Button } from "@/components/ui";
 import useAIRequestMutation from "@/hooks/Queries/openAI/useAIRequestMutation";
 import { ChatHistory, Role } from "@/types/openAIType";
 interface AIChatBoxProps {
@@ -53,9 +53,9 @@ const AIChatBox = ({ chatHistory, setHistory, ChatClose }: AIChatBoxProps) => {
   return (
     <ChatBox>
       <ChatHeader>
-        <Text color="white" fontWeight="bold">
+        <BaseText color="white" fontWeight="bold">
           AI 도서 추천받기
-        </Text>
+        </BaseText>
         <CloseButton onClick={ChatClose}>✕</CloseButton>
       </ChatHeader>
       <ChatContent ref={chatContentRef}>
@@ -73,9 +73,9 @@ const AIChatBox = ({ chatHistory, setHistory, ChatClose }: AIChatBoxProps) => {
               </>
             ) : (
               <>
-                <Text className="bg-[#19275f] text-white px-3 py-2 text-sm rounded-2xl max-w-[75%] break-words">
+                <BaseText className="bg-[#19275f] text-white px-3 py-2 text-sm rounded-2xl max-w-[75%] break-words">
                   {message.content}
-                </Text>
+                </BaseText>
                 <UserOutlined />
               </>
             )}
@@ -181,7 +181,7 @@ const ChatInput = styled.input`
   outline: none;
 `;
 
-const SendButton = twc(Button)<{ disabled?: boolean }>`
+const SendButton = twc(BaseButton)<{ disabled?: boolean }>`
   ml-2 px-4 py-2 rounded-lg
   ${({ disabled }) =>
     disabled

--- a/FE/src/components/AIChatPopup/AIChatPopup.tsx
+++ b/FE/src/components/AIChatPopup/AIChatPopup.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@components/ui";
-import { Text } from "@components/ui";
+import { BaseButton } from "@components/ui";
+import { BaseText } from "@components/ui";
 import { useRef, useState } from "react";
 import { IoChatbubbleSharp } from "react-icons/io5";
 import styled from "styled-components";
@@ -26,7 +26,7 @@ const AIChatPopup = () => {
             setHistory={setHistory}
           />
         )}
-        <Button
+        <BaseButton
           color="midnightBlue"
           fontColor="white"
           height="sm"
@@ -36,8 +36,8 @@ const AIChatPopup = () => {
           className="flex items-center justify-center gap-1"
         >
           <IoChatbubbleSharp />
-          <Text color="white">AI로 도서 추천받기</Text>
-        </Button>
+          <BaseText color="white">AI로 도서 추천받기</BaseText>
+        </BaseButton>
       </ChatPopupContainer>
     );
 };

--- a/FE/src/components/BookDisplay/ViewSelector/ViewSelector.tsx
+++ b/FE/src/components/BookDisplay/ViewSelector/ViewSelector.tsx
@@ -1,5 +1,5 @@
 import { MenuOutlined, AppstoreOutlined } from "@ant-design/icons";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import React from "react";
 import styled from "styled-components";
 
@@ -13,7 +13,7 @@ interface ViewSelectorProps {
 const ViewSelector = ({ title, viewMode, setViewMode }: ViewSelectorProps) => {
     return (
         <Container>
-            <Heading fontSize="xl" fontWeight="bold">{title}</Heading>
+            <BaseHeading fontSize="xl" fontWeight="bold">{title}</BaseHeading>
             <IconButtonGroup>
                 <ListButton
                     $active={viewMode}

--- a/FE/src/components/Detail/BookDetailCard/BookDetailCard.tsx
+++ b/FE/src/components/Detail/BookDetailCard/BookDetailCard.tsx
@@ -7,12 +7,12 @@ import {
 } from "@ant-design/icons";
 import { ShopOutlined } from "@ant-design/icons";
 import { Spacing } from "@components/Common";
-import { Text } from "@components/ui";
-import { Heading } from "@components/ui";
+import { BaseText } from "@components/ui";
+import { BaseHeading } from "@components/ui";
+import { BaseButton } from "@components/ui";
 import styled from "styled-components";
 import twc from "tailwind-styled-components";
 
-import { Button } from "@/components/ui";
 import { ERROR_IMG } from "@/constants";
 import useOpen from "@/hooks/Common/useOpen";
 import { BookDetailType } from "@/types/bookDetailType";
@@ -42,9 +42,9 @@ const BookDetailCard = ({ bookData }: BookDetailCardProps) => {
     <>
       <Card>
         <CardHeader>
-          <Heading fontSize="xl" fontWeight="bold">
+          <BaseHeading fontSize="xl" fontWeight="bold">
             {bookname}
-          </Heading>
+          </BaseHeading>
         </CardHeader>
         <CardContent>
           <BookImageWrapper>
@@ -89,8 +89,8 @@ const BookDetailCard = ({ bookData }: BookDetailCardProps) => {
             <Separator />
             <div>
               <DescriptionHeader>
-                <Heading fontSize="xl">책 소개</Heading>
-                <Button
+                <BaseHeading fontSize="xl">책 소개</BaseHeading>
+                <BaseButton
                   color="primary"
                   fontColor="white"
                   fontSize="sm"
@@ -101,7 +101,7 @@ const BookDetailCard = ({ bookData }: BookDetailCardProps) => {
                 >
                   <ShopOutlined />
                   소장 도서관
-                </Button>
+                </BaseButton>
               </DescriptionHeader>
               <Spacing height="md" />
               <Description>{description}</Description>
@@ -157,7 +157,7 @@ const StyledImage = styled.img`
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 `;
 
-const Badge = twc(Text)`
+const Badge = twc(BaseText)`
    w-2/3 flex items-center justify-center bg-gray-200 rounded px-3 py-2 text-sm mt-2 mx-auto
 `;
 

--- a/FE/src/components/Detail/CommentBox/CommentBox.tsx
+++ b/FE/src/components/Detail/CommentBox/CommentBox.tsx
@@ -1,10 +1,10 @@
 import { DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import ModalComponent from "@components/Common/Modal/Modal";
-import { Text } from "@components/ui";
+import { BaseText } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import { useState } from "react";
 import styled from "styled-components";
 
-import { Heading } from "@/components/ui";
 import { formatRelativeTime } from "@/utils";
 
 import CommentCreateTextarea from "../CommentCreateTextarea/CommentCreateTextarea";
@@ -36,10 +36,10 @@ const CommentBox = ({
         <CommentArea key={_id}>
             <CommentHeader>
                 <CommentInfoWrap>
-                    <Heading fontWeight="bold" fontSize="md">
+                    <BaseHeading fontWeight="bold" fontSize="md">
                         {username}
-                    </Heading>
-                    <Text>{formatRelativeTime(timestamp)}</Text>
+                    </BaseHeading>
+                    <BaseText>{formatRelativeTime(timestamp)}</BaseText>
                 </CommentInfoWrap>
                 <ActionWrap>
                 {isEdit ? (

--- a/FE/src/components/Detail/LibrariesDisplay/LibrariesDisplay.tsx
+++ b/FE/src/components/Detail/LibrariesDisplay/LibrariesDisplay.tsx
@@ -1,7 +1,7 @@
 import { EnvironmentOutlined, PhoneOutlined } from "@ant-design/icons";
 import KakaoMap from "@components/Common/KakaoMap/KakaoMap";
 import LoadingSpin from "@components/Common/Spin/Spin";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import styled, { css } from "styled-components";
 
 import { useLibrariesDisplayLogic } from "@/hooks/BookDetail/useLibrariesDisplayLogic";
@@ -50,9 +50,9 @@ const LibrariesDisplay = ({
                         >
                             <LibraryContent>
                                 <LibraryDetails>
-                                    <Heading fontSize="md" fontWeight="bold">
+                                    <BaseHeading fontSize="md" fontWeight="bold">
                                         {item.lib.libName}
-                                    </Heading>
+                                    </BaseHeading>
                                     <LibraryInfo>
                                         <InfoRow>
                                             <EnvironmentOutlined />

--- a/FE/src/components/Detail/LibrariesFindPopup/LibrariesFindPopup.tsx
+++ b/FE/src/components/Detail/LibrariesFindPopup/LibrariesFindPopup.tsx
@@ -1,5 +1,5 @@
 import { CloseOutlined } from "@ant-design/icons";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import styled, { keyframes } from "styled-components";
 
 import { REGIONS } from "@/constants/regions";
@@ -29,9 +29,9 @@ const LibrariesFindPopup = ({
         <Overlay>
             <Card ref={inSideRef}>
                 <PopupHeader>
-                    <Heading fontWeight="bold" fontSize="lg">
+                    <BaseHeading fontWeight="bold" fontSize="lg">
                         소장 도서관 검색
-                    </Heading>
+                    </BaseHeading>
                     <CloseOutlined onClick={closePopup} />
                 </PopupHeader>
                 <RegionSelectWrap>

--- a/FE/src/components/Detail/RegionSelectBox/RegionSelectBox.tsx
+++ b/FE/src/components/Detail/RegionSelectBox/RegionSelectBox.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@components/ui";
+import { BaseText } from "@components/ui";
 import { useRef } from "react";
 import styled, { keyframes } from "styled-components";
 
@@ -24,7 +24,7 @@ const RegionSelectBox = ({
         <>
             <LabelStyled>{regionBoxName}</LabelStyled>
             <DropdownContainer onClick={toggleOpen} ref={inSideRef}>
-                <Text fontSize="sm">{curSelected}</Text>
+                <BaseText fontSize="sm">{curSelected}</BaseText>
                 {isOpen && (
                     <DropdownList>
                         {regions.map((item) => (

--- a/FE/src/components/FavoriteSearchSection/FavoriteSearchInput/FavoriteSearchInput.tsx
+++ b/FE/src/components/FavoriteSearchSection/FavoriteSearchInput/FavoriteSearchInput.tsx
@@ -1,5 +1,5 @@
 import { SearchOutlined } from "@ant-design/icons";
-import { Input } from "@components/ui";
+import { BaseInput } from "@components/ui";
 import React, { useRef } from "react";
 import styled from "styled-components";
 
@@ -21,7 +21,7 @@ const FavoriteSearchInput: React.FC<FavoriteSearchInputProps> = ({
 
     return (
         <InputWrap onSubmit={handleSearch}>
-            <Input
+            <BaseInput
                 ref={inputRef}
                 placeholder="내가 찜한 책 검색..."
                 height="90%"

--- a/FE/src/components/FavoriteSearchSection/FavoriteSearchSection.tsx
+++ b/FE/src/components/FavoriteSearchSection/FavoriteSearchSection.tsx
@@ -1,5 +1,5 @@
 import { Spacing } from "@components/Common";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import React from "react";
 import styled from "styled-components";
 
@@ -12,9 +12,9 @@ const FavoriteSearchSection: React.FC<FavoriteSearchInputProps> = ({
 }) => {
     return (
         <InputContainer>
-            <Heading fontSize="xl" fontWeight="bold">
+            <BaseHeading fontSize="xl" fontWeight="bold">
                 Search Books
-            </Heading>
+            </BaseHeading>
             <Spacing height="md" />
             <FavoriteSearchInput setSearchText={setSearchText} />
         </InputContainer>

--- a/FE/src/components/FilterDisplay/FilterDisplay.tsx
+++ b/FE/src/components/FilterDisplay/FilterDisplay.tsx
@@ -1,5 +1,5 @@
 import { Spacing } from "@components/Common";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import styled from "styled-components";
 
 import { ORDER_ITEMS, SORT_ITEMS } from "@/constants";
@@ -25,9 +25,9 @@ const FilterDisplay = () => {
     };
     return (
         <FilterContainer>
-            <Heading fontSize="xl" fontWeight="bold">
+            <BaseHeading fontSize="xl" fontWeight="bold">
                 Filter Option
-            </Heading>
+            </BaseHeading>
             <Spacing height="md" />
             <FilterWrap>
                 <DefaultFilterBox

--- a/FE/src/components/FilterDisplay/Header/Header.tsx
+++ b/FE/src/components/FilterDisplay/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import { ReactNode } from "react";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import styled from "styled-components";
@@ -13,7 +13,7 @@ interface HeaderProps {
 const Header = ({ filterName, isOpen, children, onClick }: HeaderProps) => {
     return (
         <FilterHeader onClick={onClick}>
-            <Heading fontWeight="bold" fontSize="lg">{filterName}</Heading>
+            <BaseHeading fontWeight="bold" fontSize="lg">{filterName}</BaseHeading>
             {isOpen ? <IoIosArrowUp /> : <IoIosArrowDown />}
             {children}
         </FilterHeader>

--- a/FE/src/components/Layout/DefaultLayout.tsx
+++ b/FE/src/components/Layout/DefaultLayout.tsx
@@ -1,7 +1,7 @@
 import { Spacing } from "@components/Common";
 import { HeaderInput } from "@components/header";
 import NavigationPanel from "@components/header/NavigationPanel/NavigationPanel";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import { Link, Outlet } from "react-router-dom";
 import styled from "styled-components";
 
@@ -13,7 +13,7 @@ const DefaultLayout = () => {
             <HeaderContainer>
                 <HeaderWrap>
                     <HomeButton to={PATH.HOME}>
-                        <Heading fontWeight="bold">Meet Your Books</Heading>
+                        <BaseHeading fontWeight="bold">Meet Your Books</BaseHeading>
                     </HomeButton>
                     <PanelWrap>
                         <HeaderInput />

--- a/FE/src/components/header/DropDownBox/DropDownBox.tsx
+++ b/FE/src/components/header/DropDownBox/DropDownBox.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@components/ui";
+import { BaseText } from "@components/ui";
 import { useState } from "react";
 import styled, { keyframes } from "styled-components";
 
@@ -22,9 +22,9 @@ const DropDownBox = () => {
       onMouseEnter={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
     >
-      <Text fontWeight="bold" className="mx-auto">
+      <BaseText fontWeight="bold" className="mx-auto">
         {curSelect.label}
-      </Text>
+      </BaseText>
       {isHover && (
         <DropdownList>
           {DROP_DOWN_ITEMS.map((item) => (

--- a/FE/src/components/header/HeaderInput/HeaderInput.tsx
+++ b/FE/src/components/header/HeaderInput/HeaderInput.tsx
@@ -1,7 +1,7 @@
 import { SearchOutlined, CloseOutlined } from "@ant-design/icons";
 import { Spacing } from "@components/Common";
 import FilterDisplay from "@components/FilterDisplay/FilterDisplay";
-import { Button } from "@components/ui";
+import { BaseButton } from "@components/ui";
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import styled, { keyframes } from "styled-components";
@@ -49,7 +49,7 @@ const HeaderInput = () => {
                             />
                         </Wrap>
                         <Spacing height="sm" />
-                        <Button
+                        <BaseButton
                             width="full"
                             color="primary"
                             fontColor="white"
@@ -58,7 +58,7 @@ const HeaderInput = () => {
                             onClick={handleSubmit}
                         >
                             검색하기
-                        </Button>
+                        </BaseButton>
                     </InputWrap>
                     <FilterWrap>
                         <Spacing height="md" />

--- a/FE/src/components/ui/BaseButton/BaseButton.tsx
+++ b/FE/src/components/ui/BaseButton/BaseButton.tsx
@@ -67,7 +67,7 @@ interface ButtonProps
   children: ReactNode;
 }
 
-const Button = ({
+const BaseButton = ({
   type = "button",
   children,
   className,
@@ -104,4 +104,4 @@ const Button = ({
   );
 };
 
-export default Button;
+export default BaseButton;

--- a/FE/src/components/ui/BaseHeading/BaseHeading.tsx
+++ b/FE/src/components/ui/BaseHeading/BaseHeading.tsx
@@ -3,7 +3,7 @@ import { ReactNode, HTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
 import twc from "tailwind-styled-components";
 
-const textVariants = cva("text-black", {
+const headingVariants = cva("text-black", {
   variants: {
     fontSize: {
       xs: "text-xs",
@@ -39,25 +39,22 @@ const textVariants = cva("text-black", {
     },
   },
   defaultVariants: {
-    fontSize: "md",
+    fontSize: "2xl",
     fontWeight: "normal",
     lineHeight: "normal",
     color: "black",
   },
 });
 
-interface TextProps
-  extends VariantProps<typeof textVariants>,
-    Omit<HTMLAttributes<HTMLParagraphElement>, "color"> {
+interface HeadingProps
+  extends VariantProps<typeof headingVariants>,
+    Omit<HTMLAttributes<HTMLHeadingElement>, "color"> {
   children?: ReactNode;
 }
 
-const text = (variants: VariantProps<typeof textVariants>) =>
-  twMerge(textVariants(variants));
+const Heading = twc.h1``;
 
-const BaseText = twc.p``;
-
-const Text = ({
+const BaseHeading = ({
   fontSize,
   fontWeight,
   lineHeight,
@@ -65,18 +62,18 @@ const Text = ({
   className,
   children,
   ...props
-}: TextProps) => {
+}: HeadingProps) => {
   return (
-    <BaseText
+    <Heading
       {...props}
       className={twMerge(
-        text({ fontSize, fontWeight, lineHeight, color }),
+        headingVariants({ fontSize, fontWeight, lineHeight, color }),
         className
       )}
     >
       {children}
-    </BaseText>
+    </Heading>
   );
 };
 
-export default Text;
+export default BaseHeading;

--- a/FE/src/components/ui/BaseImage/BaseImage.tsx
+++ b/FE/src/components/ui/BaseImage/BaseImage.tsx
@@ -34,9 +34,9 @@ interface ImageProps extends VariantProps<typeof imageVariants> {
   className?: string;
 }
 
-const BaseImage = twc.img``;
+const Image = twc.img``;
 
-const Image = ({
+const BaseImage = ({
   src,
   alt = "image",
   width,
@@ -45,7 +45,7 @@ const Image = ({
   className,
 }: ImageProps) => {
   return (
-    <BaseImage
+    <Image
       src={src}
       alt={alt}
       className={twMerge(imageVariants({ width, height, rounded }), className)}
@@ -53,4 +53,4 @@ const Image = ({
   );
 };
 
-export default Image;
+export default BaseImage;

--- a/FE/src/components/ui/BaseInput/BaseInput.tsx
+++ b/FE/src/components/ui/BaseInput/BaseInput.tsx
@@ -42,7 +42,7 @@ interface InputProps
   borderRadius?: string;
 }
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
+const BaseInput = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       fontSize,
@@ -91,5 +91,5 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   }
 );
 
-Input.displayName = "Input";
-export default Input;
+BaseInput.displayName = "BaseInput";
+export default BaseInput;

--- a/FE/src/components/ui/BaseText/BaseText.tsx
+++ b/FE/src/components/ui/BaseText/BaseText.tsx
@@ -3,7 +3,7 @@ import { ReactNode, HTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
 import twc from "tailwind-styled-components";
 
-const headingVariants = cva("text-black", {
+const textVariants = cva("text-black", {
   variants: {
     fontSize: {
       xs: "text-xs",
@@ -39,22 +39,25 @@ const headingVariants = cva("text-black", {
     },
   },
   defaultVariants: {
-    fontSize: "2xl",
+    fontSize: "md",
     fontWeight: "normal",
     lineHeight: "normal",
     color: "black",
   },
 });
 
-interface HeadingProps
-  extends VariantProps<typeof headingVariants>,
-    Omit<HTMLAttributes<HTMLHeadingElement>, "color"> {
+interface TextProps
+  extends VariantProps<typeof textVariants>,
+    Omit<HTMLAttributes<HTMLParagraphElement>, "color"> {
   children?: ReactNode;
 }
 
-const BaseHeading = twc.h1``;
+const text = (variants: VariantProps<typeof textVariants>) =>
+  twMerge(textVariants(variants));
 
-const Heading = ({
+const Text = twc.p``;
+
+const BaseText = ({
   fontSize,
   fontWeight,
   lineHeight,
@@ -62,18 +65,18 @@ const Heading = ({
   className,
   children,
   ...props
-}: HeadingProps) => {
+}: TextProps) => {
   return (
-    <BaseHeading
+    <Text
       {...props}
       className={twMerge(
-        headingVariants({ fontSize, fontWeight, lineHeight, color }),
+        text({ fontSize, fontWeight, lineHeight, color }),
         className
       )}
     >
       {children}
-    </BaseHeading>
+    </Text>
   );
 };
 
-export default Heading;
+export default BaseText;

--- a/FE/src/components/ui/index.ts
+++ b/FE/src/components/ui/index.ts
@@ -1,5 +1,5 @@
-export { default as Text } from "./Text/Text";
-export { default as Heading } from "./Heading/Heading";
-export { default as Input } from "./Input/Input";
-export { default as Image } from "./Image/Image";
-export { default as Button } from "./Button/Button";
+export { default as BaseText } from "./BaseText/BaseText";
+export { default as BaseHeading } from "./BaseHeading/BaseHeading";
+export { default as BaseInput } from "./BaseInput/BaseInput";
+export { default as BaseImage } from "./BaseImage/BaseImage";
+export { default as BaseButton } from "./BaseButton/BaseButton";

--- a/FE/src/pages/BookDetail.tsx
+++ b/FE/src/pages/BookDetail.tsx
@@ -7,7 +7,7 @@ import {
     LineRechart,
 } from "@components/Detail";
 import BarRechart from "@components/Detail/BarRechart/BarRechart";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import styled from "styled-components";
 
 import useBookDetailLogic from "@/hooks/BookDetail/useBookDetailLogic";
@@ -43,7 +43,6 @@ const BookDetail = () => {
                     XDataKey="month"
                 />
             )}
-
             {loanGrps.length !== 0 && (
                 <BarRechart
                     chartName="연령대별 대출 추이"
@@ -51,10 +50,9 @@ const BookDetail = () => {
                     XDataKey="age"
                 />
             )}
-
             <CommentContainer>
                 <HeadingWrap>
-                    <Heading fontWeight="bold">리뷰</Heading>
+                    <BaseHeading fontWeight="bold">리뷰</BaseHeading>
                 </HeadingWrap>
                 <Spacing height="sm" />
                 {comments?.length === 0 ? (

--- a/FE/src/pages/Login.tsx
+++ b/FE/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { Spacing } from "@components/Common";
-import { Heading } from "@components/ui";
+import { BaseHeading } from "@components/ui";
 import { useEffect } from "react";
 import { RiKakaoTalkFill } from "react-icons/ri";
 import { useNavigate } from "react-router-dom";
@@ -40,15 +40,15 @@ const Login = () => {
             <AuthContainer>
                 <AuthCard>
                     <Header>
-                        <Heading fontWeight="bold">Meet Your Books</Heading>
+                        <BaseHeading fontWeight="bold">Meet Your Books</BaseHeading>
                     </Header>
                     <Header>
                         <AuthTitle>Login</AuthTitle>
                     </Header>
-                    <Button onClick={handleLogin}>
+                    <BaseButton onClick={handleLogin}>
                         <KakaoIcon />
                         카카오 로그인
-                    </Button>
+                    </BaseButton>
                 </AuthCard>
             </AuthContainer>
         </>

--- a/FE/transforms/rename-ui-components-to-base.cjs
+++ b/FE/transforms/rename-ui-components-to-base.cjs
@@ -1,0 +1,51 @@
+module.exports = function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const RENAME_MAP = {
+    Button: 'BaseButton',
+    Heading: 'BaseHeading',
+    Image: 'BaseImage',
+    Input: 'BaseInput',
+    Text: 'BaseText',
+  };
+
+  root.find(j.ImportDeclaration).forEach(path => {
+    const isFromTarget =
+      path.node.source.value.includes('@components/ui')
+
+    if (isFromTarget) {
+      path.node.specifiers.forEach(spec => {
+        if (spec.type === 'ImportSpecifier' && RENAME_MAP[spec.imported.name]) {
+          const newName = RENAME_MAP[spec.imported.name];
+          spec.imported.name = newName;
+
+          if (spec.local.name === spec.imported.name) {
+            spec.local.name = newName;
+          }
+        }
+      });
+    }
+  });
+
+  root.find(j.JSXIdentifier).forEach(path => {
+    const oldName = path.node.name;
+    const newName = RENAME_MAP[oldName];
+    const parent = path.parent.node;
+
+    const isJSXTag =
+      parent.type === 'JSXOpeningElement' || parent.type === 'JSXClosingElement';
+
+    const isStyledComponent =
+      parent.type === 'TaggedTemplateExpression' ||
+      (parent.type === 'CallExpression' &&
+        parent.callee &&
+        parent.callee.name === 'twc');
+
+    if (newName && isJSXTag && !isStyledComponent) {
+      path.node.name = newName;
+    }
+  });
+
+  return root.toSource({ quote: 'double' });
+};


### PR DESCRIPTION
---

## 📌 배경
- 디자인 시스템 마이그레이션의 일환으로 Button, Text 등 공통 UI 컴포넌트들을 Base* 네이밍으로 통일하고자 함
- 프로젝트 내 사용된 컴포넌트를 일일이 수작업으로 변경하기엔 비효율적이므로, jscodeshift를 사용하여 일괄 자동 리팩토링 진행

## 🎯 주요 변경 사항
1. jscodeshift transform 스크립트 작성
- @components/ui에서 import한 컴포넌트 중 Button, Text, Heading, Image, Input을 각각 Base*로 변경
2. JSX 태그 내부 컴포넌트도 자동 변경
- <Button /> → <BaseButton /> 등 자동 변경 처리
- 단, styled(Button) 또는 twc(Button)과 같이 스타일드 컴포넌트로 사용된 경우는 예외 처리
3. src/**/*.tsx 경로에 대해 변환 적용하되, ui 폴더는 제외
- UI 컴포넌트 정의 자체는 변경 대상이 아니므로 제외 처리

---

## 🔍 테스트 방법
1. npm run dev 또는 yarn dev로 개발 서버를 실행
2. 실제 <Button />, <Text /> 등이 사용된 페이지가 문제 없이 작동하는지 확인
3. 스타일이 의도대로 잘 적용되는지 시각적으로 확인
4. 주요 컴포넌트 클릭, 입력 등 기능 테스트 진행

---

## 🔗 참고 자료
- [jscodeshift 공식 문서](https://github.com/facebook/jscodeshift)

---
