### PR TITLE
refactor: twc + cva 기반으로 UI 컴포넌트 리팩토링

### DIFF
--- a/FE/src/components/ui/BaseButton/BaseButton.tsx
+++ b/FE/src/components/ui/BaseButton/BaseButton.tsx
@@ -1,6 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { ReactNode, ButtonHTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
+import twc from "tailwind-styled-components";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center transition-colors disabled:cursor-not-allowed p-6",
@@ -67,41 +68,21 @@ interface ButtonProps
   children: ReactNode;
 }
 
-const BaseButton = ({
-  type = "button",
-  children,
-  className,
-  color,
-  fontColor,
-  fontSize,
-  fontWeight,
-  width,
-  height,
-  border,
-  borderRadius,
-  ...props
-}: ButtonProps) => {
-  return (
-    <button
-      type={type}
-      className={twMerge(
-        buttonVariants({
-          color,
-          fontColor,
-          fontSize,
-          fontWeight,
-          width,
-          height,
-          border,
-          borderRadius,
-        }),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-};
+const Button = twc.button<ButtonProps>`
+  ${({ color, fontColor, fontSize, fontWeight, width, height, border, borderRadius, className }) =>
+    twMerge(
+      buttonVariants({
+        color,
+        fontColor,
+        fontSize,
+        fontWeight,
+        width,
+        height,
+        border,
+        borderRadius,
+      }),
+      className
+    )}
+`;
 
-export default BaseButton;
+export default Button;

--- a/FE/src/components/ui/BaseHeading/BaseHeading.tsx
+++ b/FE/src/components/ui/BaseHeading/BaseHeading.tsx
@@ -52,28 +52,11 @@ interface HeadingProps
   children?: ReactNode;
 }
 
-const Heading = twc.h1``;
-
-const BaseHeading = ({
-  fontSize,
-  fontWeight,
-  lineHeight,
-  color,
-  className,
-  children,
-  ...props
-}: HeadingProps) => {
-  return (
-    <Heading
-      {...props}
-      className={twMerge(
+const BaseHeading = twc.h1<HeadingProps>`
+  ${({ fontSize, fontWeight, lineHeight, color, className }) => twMerge(
         headingVariants({ fontSize, fontWeight, lineHeight, color }),
         className
       )}
-    >
-      {children}
-    </Heading>
-  );
-};
+`;
 
 export default BaseHeading;

--- a/FE/src/components/ui/BaseImage/BaseImage.tsx
+++ b/FE/src/components/ui/BaseImage/BaseImage.tsx
@@ -1,7 +1,8 @@
-import { cva, VariantProps } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
 import twc from "tailwind-styled-components";
 
+// 1. variant 정의
 const imageVariants = cva("object-cover", {
   variants: {
     width: {
@@ -34,23 +35,9 @@ interface ImageProps extends VariantProps<typeof imageVariants> {
   className?: string;
 }
 
-const Image = twc.img``;
-
-const BaseImage = ({
-  src,
-  alt = "image",
-  width,
-  height,
-  rounded,
-  className,
-}: ImageProps) => {
-  return (
-    <Image
-      src={src}
-      alt={alt}
-      className={twMerge(imageVariants({ width, height, rounded }), className)}
-    />
-  );
-};
+const BaseImage = twc.img<ImageProps>`
+  ${({ width, height, rounded, className }) =>
+    twMerge(imageVariants({ width, height, rounded }), className)}
+`;
 
 export default BaseImage;

--- a/FE/src/components/ui/BaseText/BaseText.tsx
+++ b/FE/src/components/ui/BaseText/BaseText.tsx
@@ -52,31 +52,9 @@ interface TextProps
   children?: ReactNode;
 }
 
-const text = (variants: VariantProps<typeof textVariants>) =>
-  twMerge(textVariants(variants));
-
-const Text = twc.p``;
-
-const BaseText = ({
-  fontSize,
-  fontWeight,
-  lineHeight,
-  color,
-  className,
-  children,
-  ...props
-}: TextProps) => {
-  return (
-    <Text
-      {...props}
-      className={twMerge(
-        text({ fontSize, fontWeight, lineHeight, color }),
-        className
-      )}
-    >
-      {children}
-    </Text>
-  );
-};
+const BaseText = twc.p<TextProps>`
+  ${({ fontSize, fontWeight, lineHeight, color, className }) =>
+    twMerge(textVariants({ fontSize, fontWeight, lineHeight, color }), className)}
+`;
 
 export default BaseText;


### PR DESCRIPTION
## 📌 배경
- 기존에 컴포넌트마다 BaseText, BaseButton 등의 중간 컴포넌트가 존재하며 구조가 불필요하게 복잡했음
- Tailwind 기반 디자인 시스템 구축 시, cva + twc 조합을 통해 더 선언적이고 일관된 패턴 적용 가능
- 공통 스타일을 variant로 분리해 관리하고, twMerge로 class 병합 처리까지 통합적으로 해결
- forwardRef, slot 구조 등 UI 컴포넌트 확장성을 고려해 구조 개선

## 🎯 주요 변경 사항
1. Text, Heading, Button, Image, Input 컴포넌트를 twc + cva 기반으로 통합
	- 중간 Base* 컴포넌트 제거
	- 각 HTML 태그(p, h1, img, input, button)를 기반으로 스타일 구성
2. 스타일 로직 분리 및 통일
	- class-variance-authority(cva)로 variant 중심 스타일 관리
	- ailwind-merge(twMerge)로 props.className 병합 처리
4. 모든 컴포넌트는 forwardRef 지원

---

## 🔗 참고 자료
- https://react-twc.vercel.app/docs/guides/adapting-based-on-props
- Radix UI Slot 패턴 관련 개념: https://www.radix-ui.com/docs/primitives/utilities/slot

---
